### PR TITLE
Fix Synapse crash-loop from unquoted SMTP values in homeserver.yaml

### DIFF
--- a/imageroot/bin/configure-matrix
+++ b/imageroot/bin/configure-matrix
@@ -6,19 +6,45 @@
 #
 
 import os
+import json
 import secrets
 import string
 import agent
+
+# Environment variables substituted into synapse-homeserver.yaml as string
+# scalars. Their values are user supplied (SMTP smarthost credentials and
+# sender address) and may contain characters that are reserved in YAML when
+# they appear at the start of a value ('@', '*', '&', '!', '%', quotes ...) or
+# special sequences (':', '#', '\'). They must therefore be emitted as
+# properly quoted and escaped YAML strings. Keys NOT listed here (ports,
+# booleans) are substituted verbatim so they keep their native YAML type.
+SYNAPSE_QUOTED_KEYS = (
+    "SYNAPSE_SMTP_HOST",
+    "SYNAPSE_SMTP_USERNAME",
+    "SYNAPSE_SMTP_PASSWORD",
+    "SYNAPSE_SMTP_FROM",
+)
 
 def generate_secret(length=32):
     """Generate a random secret string"""
     alphabet = string.ascii_letters + string.digits
     return ''.join(secrets.choice(alphabet) for _ in range(length))
 
-def substitute_env_vars(content, env_vars):
-    """Replace ${VAR} patterns with environment variable values"""
+def substitute_env_vars(content, env_vars, quoted_keys=()):
+    """Replace ${VAR} patterns with environment variable values.
+
+    Values whose key is listed in quoted_keys are rendered as a double quoted,
+    fully escaped string scalar via json.dumps(). A JSON string literal is also
+    a valid YAML double quoted scalar, so this protects the generated document
+    from values containing YAML reserved characters. All other values are
+    substituted verbatim, preserving numeric and boolean YAML types.
+    """
     for key, value in env_vars.items():
-        content = content.replace(f'${{{key}}}', str(value))
+        if key in quoted_keys:
+            replacement = json.dumps(str(value), ensure_ascii=False)
+        else:
+            replacement = str(value)
+        content = content.replace(f'${{{key}}}', replacement)
     return content
 
 # Read environment variables from config
@@ -72,7 +98,7 @@ template_dir = '../templates'
 
 # Process Synapse configuration
 with open(f'{template_dir}/synapse-homeserver.yaml', 'r') as f:
-    synapse_config = substitute_env_vars(f.read(), env_vars)
+    synapse_config = substitute_env_vars(f.read(), env_vars, SYNAPSE_QUOTED_KEYS)
  
 with open('synapse-config/homeserver.yaml', 'w') as f:
     f.write(synapse_config)

--- a/imageroot/templates/synapse-homeserver.yaml
+++ b/imageroot/templates/synapse-homeserver.yaml
@@ -46,7 +46,7 @@ signing_key_path: "/data/${SYNAPSE_DOMAIN_NAME}.signing.key"
 # Email configuration for notifications
 email:
   enable_notifs: ${SYNAPSE_SMTP_ENABLED}
-  smtp_host: "${SYNAPSE_SMTP_HOST}"
+  smtp_host: ${SYNAPSE_SMTP_HOST}
   smtp_port: ${SYNAPSE_SMTP_PORT}
   smtp_user: ${SYNAPSE_SMTP_USERNAME}
   smtp_pass: ${SYNAPSE_SMTP_PASSWORD}


### PR DESCRIPTION
## Fix Synapse crash-loop caused by unquoted SMTP values in homeserver.yaml

### Summary

The generated `homeserver.yaml` can become invalid YAML when the SMTP smarthost
credentials or sender address contain characters that are reserved in YAML.
When this happens Synapse fails to start and enters a crash-loop.

This PR renders the user supplied SMTP string fields as properly quoted and
escaped YAML scalars, so any value is safe regardless of its content.

### The bug

`imageroot/bin/configure-matrix` builds `homeserver.yaml` from
`imageroot/templates/synapse-homeserver.yaml` with a plain text substitution:

```python
def substitute_env_vars(content, env_vars):
    for key, value in env_vars.items():
        content = content.replace(f'${{{key}}}', str(value))
    return content
```

There is no YAML escaping. In the template the SMTP fields are substituted
without quotes:

```yaml
  smtp_host: "${SYNAPSE_SMTP_HOST}"        # only this one was quoted
  smtp_port: ${SYNAPSE_SMTP_PORT}
  smtp_user: ${SYNAPSE_SMTP_USERNAME}
  smtp_pass: ${SYNAPSE_SMTP_PASSWORD}
  ...
  notif_from: ${SYNAPSE_SMTP_FROM}
```

The values of `smtp_user`, `smtp_pass` and `notif_from` come from the cluster
smarthost settings (see `imageroot/bin/discover-smarthost`, which reads
`smtp_settings['username']` / `['password']` and derives the sender). These are
arbitrary user provided values.

A plain email address such as `noreply@example.com` is valid YAML even though it
contains `@`, because the `@` is not at the start of the scalar. The document
only breaks when a value starts with a YAML reserved character (`@`, `*`, `&`,
`!`, `%`, `{`, `[`, quotes) or contains a special sequence (`: ` or a trailing
`#`). The realistic trigger is a smarthost password that starts with `@`.

This matches the error reported in the field with image
`ghcr.io/nethserver/matrix:0.0.4` (Synapse 1.149.1):

```
yaml.scanner.ScannerError: while scanning for the next token
found character '@' that cannot start any token
  in "/data/config/homeserver.yaml", line 52, column 14
```

Line 52 is `smtp_pass`, not `notif_from`. So the sender address was not the
cause; a password (or username) beginning with a reserved character was.

The affected code is identical across releases `0.0.4` and `0.0.5` and the
current `main` branch: `synapse-homeserver.yaml` (line 49 `smtp_host` quoted,
lines 51/52/54 `smtp_user` / `smtp_pass` / `notif_from` unquoted),
`configure-matrix` (`substitute_env_vars` doing a plain `content.replace`), and
`discover-smarthost` (sourcing the SMTP username, password and sender). A `git
diff` between `0.0.4`, `0.0.5` and `main` on these three files is empty, so the
bug and the line 52 = `smtp_pass` mapping apply unchanged to the
`ghcr.io/nethserver/matrix:0.0.5` image currently on the test cluster as well.

Besides the hard crash, some values do not crash the parser but are silently
misinterpreted, which is arguably worse. For example a password `{secret}` is
parsed as a YAML mapping, `[secret]` as a list, and `&secret` as an anchor
resolving to null, so Synapse ends up with the wrong password.

### Reproduction (no NS8 required)

Render the current template with the current substitution logic and parse it:

```python
import yaml

with open("imageroot/templates/synapse-homeserver.yaml") as f:
    tpl = f.read()

env = {
    # ... other required vars ...
    "SYNAPSE_SMTP_HOST": "smtp.example.com",
    "SYNAPSE_SMTP_PORT": "587",
    "SYNAPSE_SMTP_USERNAME": "postmaster@example.com",
    "SYNAPSE_SMTP_PASSWORD": "@S3cr3t",          # starts with '@'
    "SYNAPSE_SMTP_FROM": "noreply@example.com",  # a normal address, not the trigger
    # ...
}
for k, v in env.items():
    tpl = tpl.replace("${%s}" % k, str(v))

yaml.safe_load(tpl)
```

Result on the current code:

```
yaml.scanner.ScannerError: found character '@' that cannot start any token
  in "<unicode string>", line 52, column 14
      smtp_pass: @S3cr3t
                 ^
```

The same line 52 and column 14 as the field report. Using a normal email in
`notif_from` together with a normal password parses without error, confirming
`notif_from` on its own was never the trigger.

### The fix

`substitute_env_vars` gains an optional `quoted_keys` argument. Keys listed
there are rendered with `json.dumps(value)`, which produces a double quoted,
fully escaped string literal. A JSON string literal is also a valid YAML double
quoted scalar, so this is a dependency free way to escape any string safely
(handles `@`, `*`, `&`, `!`, `{`, `[`, `"`, `\`, `#`, `:` and control
characters). All other keys keep the previous verbatim substitution, so numeric
and boolean fields (`smtp_port`, `enable_notifs`,
`require_transport_security`, `enable_tls`) keep their native YAML type and are
never turned into strings.

The four user supplied SMTP string fields are declared as quoted:

```python
SYNAPSE_QUOTED_KEYS = (
    "SYNAPSE_SMTP_HOST",
    "SYNAPSE_SMTP_USERNAME",
    "SYNAPSE_SMTP_PASSWORD",
    "SYNAPSE_SMTP_FROM",
)
```

In the template the manual quotes around `smtp_host` are removed, because the
quoting is now produced by `json.dumps`. The other three fields were already
unquoted. Only the Synapse template render passes `SYNAPSE_QUOTED_KEYS`; the
Element and Cinny JSON templates and `matrix2acrobits.yaml` are unchanged, since
they only inject a domain name (always inside JSON quotes) or generated
alphanumeric tokens, so they are not affected by this class of bug. This keeps
the change focused.

### Verification

A standalone script renders the real template and parses the output with
`yaml.safe_load` for both the original and the fixed code, over these cases:

- password starting with `@` (the real field trigger)
- password containing `"`, `'`, `\`, `#`, `: `
- values starting with `{`, `[`, `*`, `&`
- username starting with `@`, sender starting with `!`
- a normal email sender with a normal password (must pass on both, proves the
  sender alone was not the trigger)
- empty `smtp_user` and `smtp_pass`

Before the fix the original template crashes on the reserved-character cases (or
silently corrupts the value). After the fix all cases produce valid YAML and
round-trip exactly (the parsed `smtp_user` / `smtp_pass` / `notif_from` /
`smtp_host` equal the injected values), while `smtp_port` stays an int and
`enable_notifs` / `require_transport_security` stay booleans.

The repository RobotFramework suite requires a live NS8 cluster and was not run
here.

### Live cluster verification

The fix was also verified on a live NS8 cluster running the matrix module
version 0.0.5. On that node the smarthost password happened to start with `@`,
which is exactly the reserved-character trigger described above.

- With the original files, `configure-matrix` regenerated
  `homeserver.yaml` with `smtp_pass` unquoted, producing invalid YAML. Synapse
  failed to parse it with the same `ScannerError` at line 52 (the `smtp_pass`
  field) and entered a restart loop.
- After deploying the fixed `configure-matrix` and template, `smtp_pass` (and
  the other SMTP string fields) are rendered as quoted scalars, the generated
  `homeserver.yaml` is valid YAML, and `synapse.service` reaches the active
  (running) state.
- The result was cross checked A/B on the node: restoring the original files
  reproduced the crash, and restoring the fixed files restored a healthy start.

No real credentials are included in this description.

### Note

This module is declared a proof of concept in its README. This PR is proposed in
that spirit: a small, focused hardening of the config rendering so that valid
smarthost credentials cannot break Synapse startup.
